### PR TITLE
bloqueio de amostras

### DIFF
--- a/app/controllers/sample_analyses_controller.rb
+++ b/app/controllers/sample_analyses_controller.rb
@@ -12,9 +12,14 @@ class SampleAnalysesController < ApplicationController
       sample_analysis = SampleAnalysis.new(sample: @sample, lab_analysis: analysis)
       sample_analysis.save
     end
-    redirect_to request_path(@sample.request_id)
+    if @lab_analyses.blank?
+      flash[:notice] = "É necessário escolher pelo menos uma análise"
+      redirect_to new_sample_sample_analysis_path
+    else
+      redirect_to request_path(@sample.request_id)
+    end
   end
-  
+
   private
 
   def set_sample

--- a/app/models/lab_analysis.rb
+++ b/app/models/lab_analysis.rb
@@ -1,3 +1,4 @@
 class LabAnalysis < ApplicationRecord
   has_many :sample_analyses
+  validates :analysis_name, presence: true
 end

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -48,7 +48,11 @@
                   </p>
                 </div>
                 <div class="col text-right">
-                  <p><%= link_to 'Selecione as Análises', new_sample_sample_analysis_path(sample.id)  %></p>
+                  <% if SampleAnalysis.where(sample_id: sample.id).blank? %>
+                    <p><%= link_to 'Selecione as Análises', new_sample_sample_analysis_path(sample.id)  %></p>
+                  <% else %>
+                    <p>Análises Selecionadas</p>
+                  <% end %>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
bloqueio de amostras com análises vazias e inclusão de mais de uma vez a mesma análise
Renderização da página de escolha de análises laboratoriais quando o usuário não escolhe nenhuma.
Desabilitação de botões com path para new_lab_analysis quando existir mais de uma lab_analysis escolhida.